### PR TITLE
LBAP-0027 | API: Clients | Валидация email | Требования валидации email

### DIFF
--- a/src/main/java/ru/covenant/code/landing/controller/ClientsController.java
+++ b/src/main/java/ru/covenant/code/landing/controller/ClientsController.java
@@ -1,6 +1,7 @@
 package ru.covenant.code.landing.controller;
 
 
+import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,7 +26,7 @@ public class ClientsController {
     }
 
     @PostMapping
-    public ResponseEntity<ClientsCreateRsDto> addClients(@RequestBody ClientsRqDto clientsRq) {
+    public ResponseEntity<ClientsCreateRsDto> addClients(@Valid @RequestBody ClientsRqDto clientsRq) {
         return ResponseEntity.status(HttpStatus.CREATED).body(clientsService.create(clientsRq));
     }
 }

--- a/src/main/java/ru/covenant/code/landing/dto/request/ClientsRqDto.java
+++ b/src/main/java/ru/covenant/code/landing/dto/request/ClientsRqDto.java
@@ -1,9 +1,9 @@
 package ru.covenant.code.landing.dto.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
+import ru.covenant.code.landing.validation.ValidEmail;
 
 @Getter
 @Setter
@@ -15,7 +15,8 @@ public class ClientsRqDto {
     @NotBlank
     private String phone;
 
-    @Email
+    @NotBlank
+    @ValidEmail(allowedTlds = {"ru", "com", "net"})
     private String email;
 
     private String message;

--- a/src/main/java/ru/covenant/code/landing/validation/ValidEmail.java
+++ b/src/main/java/ru/covenant/code/landing/validation/ValidEmail.java
@@ -1,0 +1,21 @@
+package ru.covenant.code.landing.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = ValidEmailValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEmail {
+
+    String message() default "Некорректный формат email";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    String[] allowedTlds() default {"ru", "com"};
+}

--- a/src/main/java/ru/covenant/code/landing/validation/ValidEmailValidator.java
+++ b/src/main/java/ru/covenant/code/landing/validation/ValidEmailValidator.java
@@ -1,0 +1,36 @@
+package ru.covenant.code.landing.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ValidEmailValidator implements ConstraintValidator<ValidEmail, String> {
+
+    private Set<String> allowedTlds;
+
+    @Override
+    public void initialize(ValidEmail annotation) {
+        allowedTlds = new HashSet<>(Arrays.asList(annotation.allowedTlds()));
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+
+        if (value == null) return true;
+
+        String email = value.trim();
+        if (email.isEmpty()) return true;
+
+        int at = email.indexOf('@');
+        if (at <= 0 || at != email.lastIndexOf('@')) return false;
+
+        int lastDot = email.lastIndexOf('.');
+        if (lastDot < at + 2 || lastDot == email.length() - 1) return false;
+
+        String tld = email.substring(lastDot + 1).toLowerCase();
+        return allowedTlds.contains(tld);
+    }
+}


### PR DESCRIPTION
Добавил отдельный GlobalExceptionHandler для обработки ошибок валидации.

На текущий момент handler обрабатывает только валидацию поля email в соответствии с ТЗ (400 Bad Request, VALIDATION_ERROR, единый формат ответа).

Логика вынесена отдельно, чтобы:
	•	не засорять контроллеры;
	•	централизовать формат ошибок;
	•	упростить дальнейшее расширение валидации на другие поля при необходимости.

Сейчас класс используется минимально и решает только требования текущей задачи.